### PR TITLE
Update build.pkr.hcl - remove panther folder

### DIFF
--- a/bake/azext_bake/templates/packer/build.pkr.hcl
+++ b/bake/azext_bake/templates/packer/build.pkr.hcl
@@ -96,6 +96,7 @@ build {
       "Write-Host '>>> Waiting for GA Service (WindowsAzureGuestAgent) to start ...'",
       "while ((Get-Service WindowsAzureGuestAgent -ErrorAction SilentlyContinue) -and ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running')) { Start-Sleep -s 5 }",
       "Write-Host '>>> Sysprepping VM ...'",
+      "Remove-Item $Env:Windir\\Panther -Recurse -Force -ErrorAction SilentlyContinue",
       "Remove-Item $Env:SystemRoot\\system32\\Sysprep\\unattend.xml -Force -ErrorAction SilentlyContinue",
       # https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep-command-line-options?view=windows-11
       "& $Env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /mode:vm /generalize /quiet /quit",


### PR DESCRIPTION
Removing panther folder.  Without this current Vs 2022 Devbox images fail to sysprep properly.  https://learn.microsoft.com/en-us/azure/virtual-machines/generalize