### PR TITLE
Add user installations

### DIFF
--- a/bake/azext_bake/_constants.py
+++ b/bake/azext_bake/_constants.py
@@ -134,7 +134,8 @@ PKR_PROVISIONER_CHOCO_INSTALL = f'''
 PKR_PROVISIONER_CHOCO_MACHINE_INSTALL_LOG = f'''
   # Injected by az bake
   provisioner "file" {{
-    source = "C:/ProgramData/chocolatey/logs/chocolatey.log"
+    source = "${{path.root}}/{CHOCO_PACKAGES_CONFIG_FILE}"
+    destination = "C:/Windows/Temp/{CHOCO_PACKAGES_CONFIG_FILE}"
   }}
   {BAKE_PLACEHOLDER}'''
 

--- a/bake/azext_bake/_constants.py
+++ b/bake/azext_bake/_constants.py
@@ -134,7 +134,7 @@ PKR_PROVISIONER_CHOCO_INSTALL = f'''
 PKR_PROVISIONER_CHOCO_MACHINE_INSTALL_LOG = f'''
   # Injected by az bake
   provisioner "file" {{
-    source = "C:/ProgramData/chocolatey/logs/chocolatey.log"	
+    source = "C:/ProgramData/chocolatey/logs/chocolatey.log"
   }}
   {BAKE_PLACEHOLDER}'''
 

--- a/bake/azext_bake/_constants.py
+++ b/bake/azext_bake/_constants.py
@@ -134,8 +134,9 @@ PKR_PROVISIONER_CHOCO_INSTALL = f'''
 PKR_PROVISIONER_CHOCO_MACHINE_INSTALL_LOG = f'''
   # Injected by az bake
   provisioner "file" {{
-    source = "${{path.root}}/{CHOCO_PACKAGES_CONFIG_FILE}"
-    destination = "C:/Windows/Temp/{CHOCO_PACKAGES_CONFIG_FILE}"
+    source = "C:/ProgramData/chocolatey/logs/chocolatey.log"
+    destination = "{OUTPUT_DIR}/chocolatey.log"
+    direction = "download"
   }}
   {BAKE_PLACEHOLDER}'''
 

--- a/bake/azext_bake/_constants.py
+++ b/bake/azext_bake/_constants.py
@@ -26,6 +26,7 @@ REPO_DIR = Path(AZ_BAKE_REPO_VOLUME) if IN_BUILDER else Path(__file__).resolve()
 STORAGE_DIR = Path(AZ_BAKE_STORAGE_VOLUME) if IN_BUILDER else REPO_DIR / '.local' / 'storage'
 
 OUTPUT_DIR = STORAGE_DIR / (timestamp if IN_BUILDER else 'lastrun')
+LOCAL_USER_DIR = 'C:/Users/Public/Documents'
 
 if IN_BUILDER:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
@@ -118,7 +119,7 @@ PKR_PROVISIONER_RESTART = f'''
   }}
   {BAKE_PLACEHOLDER}'''
 
-PKR_PROVISIONER_CHOCO = f'''
+PKR_PROVISIONER_CHOCO_INSTALL = f'''
   # Injected by az bake
   provisioner "powershell" {{
     environment_vars = ["chocolateyUseWindowsCompression=false"]
@@ -127,47 +128,39 @@ PKR_PROVISIONER_CHOCO = f'''
       "& C:/Windows/Temp/chocolatey.ps1"
     ]
   }}
+  {BAKE_PLACEHOLDER}'''
 
+
+PKR_PROVISIONER_CHOCO_MACHINE_INSTALL_LOG = f'''
   # Injected by az bake
   provisioner "file" {{
-    source = "${{path.root}}/{CHOCO_PACKAGES_CONFIG_FILE}"
-    destination = "C:/Windows/Temp/{CHOCO_PACKAGES_CONFIG_FILE}"
+    source = "C:/ProgramData/chocolatey/logs/chocolatey.log"	
   }}
+  {BAKE_PLACEHOLDER}'''
 
+
+PKR_PROVISIONER_CONSENTBEHAVIOR_LOWER = f'''
   # Injected by az bake
   provisioner "powershell" {{
     elevated_user     = build.User
     elevated_password = build.Password
     inline = [
-      "choco install C:/Windows/Temp/{CHOCO_PACKAGES_CONFIG_FILE} --yes --no-progress"
+      "Set-ItemProperty 'HKLM:\\\\SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Policies\\\\System' -Name ConsentPromptBehaviorAdmin -Value 0 -type DWORD"
     ]
-  }}
-
-  # Injected by az bake
-  provisioner "file" {{
-    source = "C:/ProgramData/chocolatey/logs/chocolatey.log"
-    destination = "{OUTPUT_DIR}/chocolatey.log"
-    direction = "download"
   }}
   {BAKE_PLACEHOLDER}'''
 
-PKR_PROVISIONER_CHOCO_USER = f'''
-  # Injected by az bake
-  provisioner "file" {{
-    source = "${{path.root}}/{CHOCO_PACKAGES_USER_CONFIG_FILE}"
-    destination = "C:/Windows/Temp/{CHOCO_PACKAGES_USER_CONFIG_FILE}"
-  }}
 
+PKR_PROVISIONER_CHOCO_USER_INSTALL_SCRIPT = f'''
   # Injected by az bake
   provisioner "powershell" {{
-    elevated_user     = build.User
-    elevated_password = build.Password
     inline = [
-      "New-Item -Path 'HKLM:\\\\SOFTWARE\\\\Microsoft\\\\Active Setup\\\\Installed Components' -Name '7cc2318a-b226-4fdd-84c6-31e5f4dd9e4f' -Value 'Install Chocolatey Packages'",
-      "New-ItemProperty 'HKLM:\\\\SOFTWARE\\\\Microsoft\\\\Active Setup\\\\Installed Components\\\\7cc2318a-b226-4fdd-84c6-31e5f4dd9e4f' -Name StubPath -Value 'choco install C:/Windows/Temp/{CHOCO_PACKAGES_USER_CONFIG_FILE} --yes --no-progress'"
+      "(new-object net.webclient).DownloadFile('https://raw.githubusercontent.com/colbylwilliams/az-bake/main/examples/scripts/Install-ChocoUser.ps1', 'C:/Users/Public/Documents/Install-ChocoUser.ps1')",
+      "(new-object net.webclient).DownloadFile('https://raw.githubusercontent.com/colbylwilliams/az-bake/main/examples/scripts/Reset-AdminConsentBehavior.ps1', 'C:/Users/Public/Documents/Reset-AdminConsentBehavior.ps1')",
     ]
   }}
   {BAKE_PLACEHOLDER}'''
+
 
 WINGET_SETTINGS_FILE = 'settings.json'
 

--- a/bake/azext_bake/_data.py
+++ b/bake/azext_bake/_data.py
@@ -101,6 +101,7 @@ class ChocoDefaults:
 
         self.source = obj.get('source', None)
         self.install_arguments = obj.get('installArguments', None)
+        self.restart = obj.get('restart', False)
 
 
 @dataclass
@@ -113,6 +114,7 @@ class ChocoPackage:
     install_arguments: Optional[str] = None
     package_parameters: Optional[str] = None
     user: bool = False
+    restart: bool = False
 
     def __init__(self, obj: dict, path: Path = None) -> None:
         _validate_data_object(ChocoPackage, obj, path=path, parent_key='install.choco')
@@ -123,6 +125,7 @@ class ChocoPackage:
         self.install_arguments = obj.get('installArguments', None)
         self.package_parameters = obj.get('packageParameters', None)
         self.user = obj.get('user', False)
+        self.restart = obj.get('restart', False)
 
     @property
     def id_only(self):

--- a/bake/azext_bake/_data.py
+++ b/bake/azext_bake/_data.py
@@ -209,6 +209,16 @@ class ImageInstallWinget:
         self.defaults = WingetDefaults(obj['defaults'], path) if 'defaults' in obj else None
 
 
+@dataclass
+class ImageInstallActiveSetup:
+    # required
+    commands: List[str] = field(default_factory=list)
+
+    def __init__(self, obj: dict) -> None:
+        _validate_data_object(ImageInstallActiveSetup, obj, parent_key='install.activesetup')
+
+        self.commands = [str]
+
 # --------------------------------
 # Image > Install
 # --------------------------------
@@ -220,6 +230,7 @@ class ImageInstall:
     scripts: Optional[ImageInstallScripts] = None
     choco: Optional[ImageInstallChoco] = None
     winget: Optional[ImageInstallWinget] = None
+    activesetup: Optional[ImageInstallActiveSetup] = None
 
     def __init__(self, obj: dict, path: Path = None) -> None:
         _validate_data_object(ImageInstall, obj, path=path, parent_key='install')
@@ -227,6 +238,7 @@ class ImageInstall:
         self.scripts = ImageInstallScripts(obj['scripts'], path) if 'scripts' in obj else None
         self.choco = ImageInstallChoco(obj['choco'], path) if 'choco' in obj else None
         self.winget = ImageInstallWinget(obj['winget'], path) if 'winget' in obj else None
+        self.activesetup = ImageInstallActiveSetup(obj['activesetup']) if 'activesetup' in obj else None
 
 
 # --------------------------------

--- a/bake/azext_bake/_packer.py
+++ b/bake/azext_bake/_packer.py
@@ -256,7 +256,10 @@ def inject_choco_machine_provisioners(image_dir: Path, choco_packages):
     for i, choco_package in enumerate(choco_packages):
         current_index = i
         choco_system_provisioner += f'      "choco install {choco_package.id} {get_choco_package_setup(choco_package)}"'
-
+        
+        if choco_package.restart is True:
+            inject_restart = True
+            break
         if i < len(choco_packages) - 1:
             choco_system_provisioner += ',\n'
 
@@ -270,7 +273,7 @@ def inject_choco_machine_provisioners(image_dir: Path, choco_packages):
         inject_restart_provisioner(image_dir)
 
         if current_index < len(choco_packages) - 1:
-            inject_powershell_provisioner(image_dir, choco_packages[current_index + 1:])
+            inject_choco_machine_provisioners(image_dir, choco_packages[current_index + 1:])
 
 
 def inject_choco_user_provisioners(image_dir: Path, choco_packages):

--- a/bake/azext_bake/_packer.py
+++ b/bake/azext_bake/_packer.py
@@ -9,18 +9,20 @@ import os
 import shutil
 import subprocess
 import sys
+import uuid
 
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from azure.cli.core.azclierror import ValidationError
 
-from ._constants import (BAKE_PLACEHOLDER, CHOCO_PACKAGES_CONFIG_FILE, CHOCO_PACKAGES_USER_CONFIG_FILE,
-                         PKR_AUTO_VARS_FILE, PKR_BUILD_FILE, PKR_DEFAULT_VARS, PKR_PROVISIONER_CHOCO,
-                         PKR_PROVISIONER_CHOCO_USER, PKR_PROVISIONER_RESTART, PKR_PROVISIONER_UPDATE,
-                         PKR_PROVISIONER_WINGET_INSTALL, PKR_VARS_FILE, WINGET_SETTINGS_FILE, WINGET_SETTINGS_JSON)
+from ._constants import (BAKE_PLACEHOLDER, PKR_PROVISIONER_CHOCO_MACHINE_INSTALL_LOG,
+                         PKR_AUTO_VARS_FILE, PKR_BUILD_FILE, PKR_DEFAULT_VARS, PKR_PROVISIONER_CHOCO_INSTALL,
+                         PKR_PROVISIONER_RESTART, PKR_PROVISIONER_UPDATE, LOCAL_USER_DIR,
+                         PKR_PROVISIONER_WINGET_INSTALL, PKR_VARS_FILE, WINGET_SETTINGS_FILE, WINGET_SETTINGS_JSON,
+                         PKR_PROVISIONER_CONSENTBEHAVIOR_LOWER, PKR_PROVISIONER_CHOCO_USER_INSTALL_SCRIPT)
 from ._data import Gallery, Image, PowershellScript, Sandbox, WingetPackage, get_dict
-from ._utils import get_logger, get_templates_path
+from ._utils import get_logger, get_templates_path, get_choco_package_setup
 
 logger = get_logger(__name__)
 
@@ -218,16 +220,96 @@ def inject_powershell_provisioner(image_dir: Path, powershell_scripts: Sequence[
             inject_powershell_provisioner(image_dir, powershell_scripts[current_index + 1:])
 
 
-def inject_choco_provisioners(image_dir: Path, config_xml, for_user=False):
-    '''Injects the chocolatey provisioners into the packer build file'''
-    # create the choco packages config file
-    file_name = CHOCO_PACKAGES_USER_CONFIG_FILE if for_user else CHOCO_PACKAGES_CONFIG_FILE
+def inject_choco_install_provisioners(image_dir: Path):
+    '''Injects the chocolatey install provisioner into the packer build file'''
+    _inject_provisioner(image_dir, PKR_PROVISIONER_CHOCO_INSTALL)
 
-    logger.info(f'Creating file: {image_dir / file_name}')
-    with open(image_dir / file_name, 'w', encoding='utf-8') as f:
-        f.write(config_xml)
 
-    _inject_provisioner(image_dir, PKR_PROVISIONER_CHOCO_USER if for_user else PKR_PROVISIONER_CHOCO)
+def inject_choco_user_script_provisioners(image_dir: Path):
+    '''Injects the chocolatey user script provisioner into the packer build file'''
+    _inject_provisioner(image_dir, PKR_PROVISIONER_CHOCO_USER_INSTALL_SCRIPT)
+
+
+def inject_choco_user_consent_provisioners(image_dir: Path):
+    '''Injects the chocolatey user script provisioner into the packer build file'''
+    _inject_provisioner(image_dir, PKR_PROVISIONER_CONSENTBEHAVIOR_LOWER)
+
+
+def inject_choco_machine_log_provisioners(image_dir: Path):
+    '''Injects the chocolatey install provisioner into the packer build file'''
+    _inject_provisioner(image_dir, PKR_PROVISIONER_CHOCO_MACHINE_INSTALL_LOG)
+
+
+def inject_choco_machine_provisioners(image_dir: Path, choco_packages):
+    '''Injects the chocolatey machine provisioner into the packer build file'''
+
+    current_index = 0
+    inject_restart = False
+
+    choco_system_provisioner = '''
+  # Injected by az bake
+  provisioner "powershell" {
+    elevated_user     = build.User
+    elevated_password = build.Password
+    inline = [
+'''
+    for i, choco_package in enumerate(choco_packages):
+        current_index = i
+        choco_system_provisioner += f'      "choco install {choco_package.id} {get_choco_package_setup(choco_package)}"'
+
+        if i < len(choco_packages) - 1:
+            choco_system_provisioner += ',\n'
+
+    choco_system_provisioner += f'''
+    ]
+  }}
+  {BAKE_PLACEHOLDER}'''
+    _inject_provisioner(image_dir, choco_system_provisioner)
+
+    if inject_restart:
+        inject_restart_provisioner(image_dir)
+
+        if current_index < len(choco_packages) - 1:
+            inject_powershell_provisioner(image_dir, choco_packages[current_index + 1:])
+
+
+def inject_choco_user_provisioners(image_dir: Path, choco_packages):
+    '''Injects the chocolatey user provisioner into the packer build file'''
+
+    choco_user_provisioner = '''
+  # Injected by az bake
+  provisioner "powershell" {
+    elevated_user     = build.User
+    elevated_password = build.Password
+    inline = [
+      "Write-Host 'Setting up User installation via Active Setup'",
+'''
+
+    activesetup_id = uuid.uuid4()
+    base_reg_key = 'HKLM:\\\\SOFTWARE\\\\Microsoft\\\\Active Setup\\\\Installed Components\\\\'
+
+    for i, choco_package in enumerate(choco_packages):
+        choco_str = get_choco_package_setup(choco_package)
+        key_name = f'{i}{activesetup_id}'
+        base_reg_key_newitem = f'      "New-Item \'{base_reg_key}\' -Name {key_name}'
+        base_reg_key_property = f'      "New-ItemProperty \'{base_reg_key}{key_name}\''
+        script_value = f'Powershell -File {LOCAL_USER_DIR}/Install-ChocoUser.ps1'
+        stubpath_value = f'{script_value} -PackageId {choco_package.id} -PackageArguments \\"{choco_str}\\"'
+        choco_user_provisioner += f'{base_reg_key_newitem} -Value \'AZ Bake {choco_package.id} Setup\'", \n'
+        choco_user_provisioner += f'{base_reg_key_property} -Name \'StubPath\' -Value \'{stubpath_value}\'", \n'
+
+    key_name = f'>9{activesetup_id}'
+    base_reg_key_newitem = f'      "New-Item \'{base_reg_key}\' -Name \'{key_name}\''
+    base_reg_key_property = f'      "New-ItemProperty \'{base_reg_key}{key_name}\''
+    script_value = f'Powershell -File {LOCAL_USER_DIR}/Reset-AdminConsentBehavior.ps1'
+    choco_user_provisioner += f'{base_reg_key_newitem} -Value \'AZ Bake Admin Behavior Setup\'", \n'
+    choco_user_provisioner += f'{base_reg_key_property} -Name \'StubPath\' -Value \'{script_value}\'"\n'
+
+    choco_user_provisioner += f'''
+    ]
+  }}
+  {BAKE_PLACEHOLDER}'''
+    _inject_provisioner(image_dir, choco_user_provisioner)
 
 
 def inject_winget_provisioners(image_dir: Path, winget_packages: Sequence[WingetPackage]):

--- a/bake/azext_bake/_utils.py
+++ b/bake/azext_bake/_utils.py
@@ -197,7 +197,7 @@ def get_choco_package_setup(package: ChocoPackage) -> str:
     choco_setup_string = ''
 
     for key in pkg:
-        if key.__ne__("id"):
+        if key not in ('id', 'restart'):
             choco_setup_string += f" --{key} '{pkg[key]}'"
 
     choco_setup_string += '--yes --no-progress'

--- a/bake/azext_bake/_utils.py
+++ b/bake/azext_bake/_utils.py
@@ -188,6 +188,22 @@ def get_choco_package_config(packages: Sequence[ChocoPackage], indent=2) -> str:
     return xml_string
 
 
+def get_choco_package_setup(package: ChocoPackage) -> str:
+    '''Get the chocolatey package setup string'''
+    logger.info('Getting choco package setup contents from install dict')
+    pkg = get_dict(package)
+    if 'user' in pkg:
+        del pkg['user']
+    choco_setup_string = ''
+
+    for key in pkg:
+        if key.__ne__("id"):
+            choco_setup_string += f" --{key} '{pkg[key]}'"
+
+    choco_setup_string += '--yes --no-progress'
+    return choco_setup_string
+
+
 def get_install_winget(image: Image):
     # TODO
     '''Get the dict for the install winget section supplemented by the index'''
@@ -251,6 +267,17 @@ def get_install_powershell_scripts(image: Image) -> List[PowershellScript]:
     return scripts
 
 
+def get_install_activesetup_commands(image: Image) -> List[str]:
+    logger.info('Getting activesetup commands dictionary from image.yaml')
+    if image.install is None or image.install.activesetup is None:
+        return None
+
+    if image.install.activesetup.commands is None:
+        raise ValidationError('Image install.activesetup must include a commands section')
+
+    return image.install.activesetup.commands
+
+
 def _validate_file_path(path, name=None) -> Path:
     file_path = (path if isinstance(path, Path) else Path(path)).resolve()
     not_exists = f'Could not find {name} file at {file_path}' if name else f'{file_path} is not a file or directory'
@@ -259,6 +286,7 @@ def _validate_file_path(path, name=None) -> Path:
     if not file_path.is_file():
         raise ValidationError(f'{file_path} is not a file')
     return file_path
+
 # def _get_current_user_object_id(graph_client):
 #     try:
 #         current_user = graph_client.signed_in_user.get()

--- a/bake/azext_bake/custom.py
+++ b/bake/azext_bake/custom.py
@@ -453,7 +453,7 @@ def bake_builder_build(cmd, sandbox: Sandbox = None, gallery: Gallery = None, im
                 inject_choco_user_script_provisioners(image.dir)
                 inject_choco_user_consent_provisioners(image.dir)
                 inject_choco_user_provisioners(image.dir, user_choco_packages)
-                
+
         # winget_config = get_install_winget(image)
         # if winget_config:
         #     inject_winget_provisioners(image.dir, winget_config)

--- a/bake/azext_bake/custom.py
+++ b/bake/azext_bake/custom.py
@@ -24,11 +24,14 @@ from ._constants import (BAKE_YAML_SCHEMA, DEVOPS_PIPELINE_CONTENT, DEVOPS_PIPEL
                          IMAGE_DEFAULT_BASE_WINDOWS, IMAGE_YAML_SCHEMA, IN_BUILDER)
 from ._data import Gallery, Image, Sandbox, get_dict
 from ._github import get_github_latest_release_version, get_github_release, get_release_templates, get_template_url
-from ._packer import (copy_packer_files, inject_choco_provisioners, inject_powershell_provisioner,
+from ._packer import (copy_packer_files, inject_choco_install_provisioners,
+                      inject_choco_machine_provisioners, inject_choco_user_script_provisioners,
+                      inject_choco_user_provisioners, inject_choco_machine_log_provisioners,
+                      inject_powershell_provisioner, inject_choco_user_consent_provisioners,
                       inject_update_provisioner, packer_execute, save_packer_vars_file)
 from ._repos import Repo
 from ._sandbox import get_builder_subnet_id, get_sandbox_resource_names
-from ._utils import (copy_to_builder_output_dir, get_choco_package_config, get_install_choco_packages,
+from ._utils import (copy_to_builder_output_dir, get_install_choco_packages,
                      get_install_powershell_scripts, get_logger, get_templates_path)
 
 logger = get_logger(__name__)
@@ -294,7 +297,7 @@ def bake_image_bump(cmd, repository_path='./', image_names: Sequence[str] = None
         version_old = parse_version(version)
 
         if len(version_old.release) != 3:
-            raise CLIError(f'Version must be in the format major.minro.patch (found: {version})')
+            raise CLIError(f'Version must be in the format major.minor.patch (found: {version})')
 
         n_major = version_old.major + 1 if major else version_old.major
         n_minor = 0 if major else version_old.minor + 1 if minor else version_old.minor
@@ -436,16 +439,21 @@ def bake_builder_build(cmd, sandbox: Sandbox = None, gallery: Gallery = None, im
 
         choco_packages = get_install_choco_packages(image)
 
-        user_choco_packages = [package for package in choco_packages if package.user]
-        if user_choco_packages:
-            choco_user_config = get_choco_package_config(user_choco_packages)
-            inject_choco_provisioners(image.dir, choco_user_config, for_user=True)
+        # install choco packages if packages
+        if choco_packages:
+            inject_choco_install_provisioners(image.dir)
 
-        machine_choco_packages = [package for package in choco_packages if not package.user]
-        if machine_choco_packages:
-            machine_choco_config = get_choco_package_config(machine_choco_packages)
-            inject_choco_provisioners(image.dir, machine_choco_config, for_user=False)
+            machine_choco_packages = [package for package in choco_packages if not package.user]
+            if machine_choco_packages:
+                inject_choco_machine_provisioners(image.dir, machine_choco_packages)
+                inject_choco_machine_log_provisioners(image.dir)
 
+            user_choco_packages = [package for package in choco_packages if package.user]
+            if user_choco_packages:
+                inject_choco_user_script_provisioners(image.dir)
+                inject_choco_user_consent_provisioners(image.dir)
+                inject_choco_user_provisioners(image.dir, user_choco_packages)
+                
         # winget_config = get_install_winget(image)
         # if winget_config:
         #     inject_winget_provisioners(image.dir, winget_config)

--- a/bake/azext_bake/templates/install/choco.json
+++ b/bake/azext_bake/templates/install/choco.json
@@ -6,5 +6,13 @@
     "postman": {
         "id": "postman",
         "user": true
+    },
+    "wsl2": {
+        "id": "wsl2",
+        "user": true
+    },
+    "docker-desktop": {
+        "id": "docker-desktop",
+        "user": true
     }
 }

--- a/examples/scripts/Install-ChocoUser.ps1
+++ b/examples/scripts/Install-ChocoUser.ps1
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[cmdletbinding()]
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$PackageId,
+
+    [Parameter(Mandatory=$false)]
+    [string]$PackageArguments
+)
+
+function Show-Notification {
+    [cmdletbinding()]
+    Param (
+        [string]
+        $ToastTitle,
+
+        [string]
+        [parameter(ValueFromPipeline)]
+        $ToastText
+    )
+
+    [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null
+    $Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+
+    $RawXml = [xml] $Template.GetXml()
+    ($RawXml.toast.visual.binding.text|where {$_.id -eq "1"}).AppendChild($RawXml.CreateTextNode($ToastTitle)) > $null
+    ($RawXml.toast.visual.binding.text|where {$_.id -eq "2"}).AppendChild($RawXml.CreateTextNode($ToastText)) > $null
+
+    $SerializedXml = New-Object Windows.Data.Xml.Dom.XmlDocument
+    $SerializedXml.LoadXml($RawXml.OuterXml)
+
+    $Toast = [Windows.UI.Notifications.ToastNotification]::new($SerializedXml)
+    $Toast.Tag = "AZBake"
+    $Toast.Group = "AZBake"
+    $Toast.ExpirationTime = [DateTimeOffset]::Now.AddMinutes(1)
+
+    $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("AZBake")
+    $Notifier.Show($Toast);
+}
+
+# Don't use C:\Windows\Temp as requires admin elevation
+# Add logging
+# Check if folder exists
+$LogDir = "C:\Temp"
+if (-not (Test-Path -LiteralPath $LogDir)) {
+    New-Item -Path $LogDir -ItemType Directory -ErrorAction Stop | Out-Null #-Force
+}
+
+$Log = Join-Path -Path $LogDir -ChildPath "chocouserinstall.log"
+if (-not (Test-Path -LiteralPath $Log)) {
+    New-Item -Path $Log -ItemType File -ErrorAction Stop | Out-Null #-Force
+}
+
+Add-Content -Path $log -Value "Starting check to see if user has administrator privileges. $(Get-Date)"
+
+# Unable to use below as the Administrator group isn't shown.
+# ([Security.Principal.WindowsIdentity]::GetCurrent().Groups | Select-String 'S-1-5-32-544')
+
+# Check if user is in administrator group
+if ($null -ne (whoami /groups /fo csv | ConvertFrom-Csv | Where-Object { $_.SID -eq "S-1-5-32-544" })) {
+
+    Add-Content -Path $log -Value "User has Administrator privileges: $(Get-Date)"
+
+    # Self-elevate the script if required
+    if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+        if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
+
+            # Bound Arguments aren't filling in the command line.
+            #$CommandLine = "-File `"" + $MyInvocation.MyCommand.Path + "`" " + $MyInvocation.BoundArguments
+            $CommandLine = "-File `"" + $MyInvocation.MyCommand.Path + "`" "
+
+            foreach ($param in $MyInvocation.BoundParameters.GetEnumerator()){
+                $CommandLine += " -" + $param.key + " """ + $param.value + """"
+            }
+
+            Start-Process -FilePath PowerShell.exe -Verb Runas -ArgumentList $CommandLine -WindowStyle Hidden
+            Exit
+        }
+    }
+}
+
+Add-Content -Path $log -Value "Deploying: $($PackageId): $($PackageArguments): $(Get-Date)"
+
+# Check if package is installed
+$toastTitle = "DevBox User Install"
+Show-Notification -ToastTitle $toastTitle -ToastText "Checking for $PackageId"
+Add-Content -Path $log -Value "Checking for $($PackageId): $(Get-Date)"
+$current = & choco.exe list --exact $PackageId --local-only --limit-output
+
+if (-not $current) {
+    Show-Notification -ToastTitle $toastTitle -ToastText "Installing $PackageId"
+    Add-Content -Path $log -Value "Begin installing $($PackageId): $(Get-Date)"
+
+    & choco.exe install $PackageId $($PackageArguments -split(" "))
+
+    if ($LASTEXITCODE -ne 0) {
+        Show-Notification -ToastTitle $toastTitle -ToastText "Failed Installing $PackageId"
+        Add-Content -Path $log -Value "Failed to install $($PackageId): $(Get-Date)"
+        Add-Content -Path $log -Value "Chocolatey log files are in C:\Windows\ProgramData\chocoportable\logs : $(Get-Date)"
+        return 1
+    }
+    Show-Notification -ToastTitle $toastTitle -ToastText "Finished installing $PackageId"
+    Add-Content -Path $log -Value "Finished installing $($PackageId): $(Get-Date)"
+}
+else {
+    Show-Notification -ToastTitle $toastTitle -ToastText "$PackageId already installed."
+    Add-Content -Path $log -Value "$($PackageId) already installed: $(Get-Date)"
+}

--- a/examples/scripts/Reset-AdminConsentBehavior.ps1
+++ b/examples/scripts/Reset-AdminConsentBehavior.ps1
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Check if user is in administrator group
+if ($null -ne (whoami /groups /fo csv | ConvertFrom-Csv | Where-Object { $_.SID -eq "S-1-5-32-544" })) {
+
+    # Self-elevate the script if required
+    if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+        if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
+
+            $CommandLine = "-File `"" + $MyInvocation.MyCommand.Path + "`" "
+
+            Start-Process -FilePath PowerShell.exe -Verb Runas -ArgumentList $CommandLine -WindowStyle Hidden
+            Exit
+        }
+    }
+}
+else {
+    Exit
+}
+
+Set-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System' -Name ConsentPromptBehaviorAdmin -Value 5 -type DWORD

--- a/schema/bake.schema.json
+++ b/schema/bake.schema.json
@@ -85,7 +85,7 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Name of the Azure Compurt Gallery to publish to"
+                    "description": "Name of the Azure Compute Gallery to publish to"
                 },
                 "resourceGroup": {
                     "type": "string",


### PR DESCRIPTION
Add the ability to install per user software (ie Docker desktop)
- Add data class for ActiveSetup
- Change packer file creation to explicitly install choco packages per machine
- Change packer to add activesetup registry to call scripts per user
- Change install behavior to not show UAC when elevating user (reset post install)
- InstallChocoUser.ps1 which elevates user to admin (if possible) and runs choco
- Reset-AdminConsentBehaviour.ps1 which resets to admin behavior to the default 
- Fix typos
- Not using C:\Windows\Temp folder for scripts and logging, requires admin elevation to access.